### PR TITLE
BR-2595 - fixing unit tests

### DIFF
--- a/m3ter-java-core/src/main/kotlin/com/m3ter/sdk/models/Aggregation.kt
+++ b/m3ter-java-core/src/main/kotlin/com/m3ter/sdk/models/Aggregation.kt
@@ -30,7 +30,7 @@ private constructor(
     private val version: JsonField<Long> = JsonMissing.of(),
     @JsonProperty("aggregation")
     @ExcludeMissing
-    private val aggregation: JsonField<Aggregation> = JsonMissing.of(),
+    private val aggregation: JsonField<AggregationFunction> = JsonMissing.of(),
     @JsonProperty("code") @ExcludeMissing private val code: JsonField<String> = JsonMissing.of(),
     @JsonProperty("createdBy")
     @ExcludeMissing
@@ -104,7 +104,7 @@ private constructor(
      * - **UNIQUE**. Uses unique values and returns a count of the number of unique values. Can be
      *   applied to a **Metadata** `targetField`.
      */
-    fun aggregation(): Optional<Aggregation> =
+    fun aggregation(): Optional<AggregationFunction> =
         Optional.ofNullable(aggregation.getNullable("aggregation"))
 
     /** Code of the Aggregation. A unique short code to identify the Aggregation. */
@@ -242,7 +242,7 @@ private constructor(
      */
     @JsonProperty("aggregation")
     @ExcludeMissing
-    fun _aggregation(): JsonField<Aggregation> = aggregation
+    fun _aggregation(): JsonField<AggregationFunction> = aggregation
 
     /** Code of the Aggregation. A unique short code to identify the Aggregation. */
     @JsonProperty("code") @ExcludeMissing fun _code(): JsonField<String> = code
@@ -395,7 +395,7 @@ private constructor(
 
         private var id: JsonField<String>? = null
         private var version: JsonField<Long>? = null
-        private var aggregation: JsonField<Aggregation> = JsonMissing.of()
+        private var aggregation: JsonField<AggregationFunction> = JsonMissing.of()
         private var code: JsonField<String> = JsonMissing.of()
         private var createdBy: JsonField<String> = JsonMissing.of()
         private var customFields: JsonField<CustomFields> = JsonMissing.of()
@@ -479,7 +479,7 @@ private constructor(
          * - **UNIQUE**. Uses unique values and returns a count of the number of unique values. Can
          *   be applied to a **Metadata** `targetField`.
          */
-        fun aggregation(aggregation: Aggregation) = aggregation(JsonField.of(aggregation))
+        fun aggregation(aggregation: AggregationFunction) = aggregation(JsonField.of(aggregation))
 
         /**
          * Specifies the computation method applied to usage data collected in `targetField`.
@@ -502,7 +502,7 @@ private constructor(
          * - **UNIQUE**. Uses unique values and returns a count of the number of unique values. Can
          *   be applied to a **Metadata** `targetField`.
          */
-        fun aggregation(aggregation: JsonField<Aggregation>) = apply {
+        fun aggregation(aggregation: JsonField<AggregationFunction>) = apply {
             this.aggregation = aggregation
         }
 
@@ -821,7 +821,7 @@ private constructor(
      * - **UNIQUE**. Uses unique values and returns a count of the number of unique values. Can be
      *   applied to a **Metadata** `targetField`.
      */
-    class Aggregation
+    class AggregationFunction
     @JsonCreator
     private constructor(
         private val value: JsonField<String>,
@@ -845,7 +845,7 @@ private constructor(
 
             @JvmField val UNIQUE = of("UNIQUE")
 
-            @JvmStatic fun of(value: String) = Aggregation(JsonField.of(value))
+            @JvmStatic fun of(value: String) = AggregationFunction(JsonField.of(value))
         }
 
         enum class Known {
@@ -900,7 +900,7 @@ private constructor(
                 return true
             }
 
-            return /* spotless:off */ other is Aggregation && value == other.value /* spotless:on */
+            return /* spotless:off */ other is AggregationFunction && value == other.value /* spotless:on */
         }
 
         override fun hashCode() = value.hashCode()
@@ -1149,8 +1149,11 @@ private constructor(
         if (this === other) {
             return true
         }
+        if (other !is Aggregation) {
+            return false
+        }
 
-        return /* spotless:off */ other is Aggregation && id == other.id && version == other.version && aggregation == other.aggregation && code == other.code && createdBy == other.createdBy && customFields == other.customFields && defaultValue == other.defaultValue && dtCreated == other.dtCreated && dtLastModified == other.dtLastModified && lastModifiedBy == other.lastModifiedBy && meterId == other.meterId && name == other.name && quantityPerUnit == other.quantityPerUnit && rounding == other.rounding && segmentedFields == other.segmentedFields && segments == other.segments && targetField == other.targetField && unit == other.unit && additionalProperties == other.additionalProperties /* spotless:on */
+        return /* spotless:off */ id == other.id && version == other.version && aggregation == other.aggregation && code == other.code && createdBy == other.createdBy && customFields == other.customFields && defaultValue == other.defaultValue && dtCreated == other.dtCreated && dtLastModified == other.dtLastModified && lastModifiedBy == other.lastModifiedBy && meterId == other.meterId && name == other.name && quantityPerUnit == other.quantityPerUnit && rounding == other.rounding && segmentedFields == other.segmentedFields && segments == other.segments && targetField == other.targetField && unit == other.unit && additionalProperties == other.additionalProperties /* spotless:on */
     }
 
     /* spotless:off */

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/AggregationFunctionCreateParamsTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/AggregationFunctionCreateParamsTest.kt
@@ -6,7 +6,7 @@ import com.m3ter.sdk.core.JsonValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class AggregationCreateParamsTest {
+class AggregationFunctionCreateParamsTest {
 
     @Test
     fun createAggregationCreateParams() {

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/AggregationFunctionListParamsTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/AggregationFunctionListParamsTest.kt
@@ -7,11 +7,11 @@ import com.m3ter.sdk.core.http.QueryParams
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class CompoundAggregationListParamsTest {
+class AggregationFunctionListParamsTest {
 
     @Test
-    fun createCompoundAggregationListParams() {
-        CompoundAggregationListParams.builder()
+    fun createAggregationListParams() {
+        AggregationListParams.builder()
             .orgId("orgId")
             .addCode("string")
             .addId("string")
@@ -24,7 +24,7 @@ class CompoundAggregationListParamsTest {
     @Test
     fun getQueryParams() {
         val params =
-            CompoundAggregationListParams.builder()
+            AggregationListParams.builder()
                 .orgId("orgId")
                 .addCode("string")
                 .addId("string")
@@ -37,20 +37,20 @@ class CompoundAggregationListParamsTest {
         expected.put("ids", "string")
         expected.put("nextToken", "nextToken")
         expected.put("pageSize", "1")
-        expected.put("productId", JsonValue.from(mapOf<String, Any>()))
+        expected.put("productId", JsonValue.from(mapOf<String, Any>()).toString())
         assertThat(params.getQueryParams()).isEqualTo(expected.build())
     }
 
     @Test
     fun getQueryParamsWithoutOptionalFields() {
-        val params = CompoundAggregationListParams.builder().orgId("orgId").build()
+        val params = AggregationListParams.builder().orgId("orgId").build()
         val expected = QueryParams.builder()
         assertThat(params.getQueryParams()).isEqualTo(expected.build())
     }
 
     @Test
     fun getPathParam() {
-        val params = CompoundAggregationListParams.builder().orgId("orgId").build()
+        val params = AggregationListParams.builder().orgId("orgId").build()
         assertThat(params).isNotNull
         // path param "orgId"
         assertThat(params.getPathParam(0)).isEqualTo("orgId")

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/AggregationFunctionRetrieveParamsTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/AggregationFunctionRetrieveParamsTest.kt
@@ -5,16 +5,16 @@ package com.m3ter.sdk.models
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class CompoundAggregationRetrieveParamsTest {
+class AggregationFunctionRetrieveParamsTest {
 
     @Test
-    fun createCompoundAggregationRetrieveParams() {
-        CompoundAggregationRetrieveParams.builder().orgId("orgId").id("id").build()
+    fun createAggregationRetrieveParams() {
+        AggregationRetrieveParams.builder().orgId("orgId").id("id").build()
     }
 
     @Test
     fun getPathParam() {
-        val params = CompoundAggregationRetrieveParams.builder().orgId("orgId").id("id").build()
+        val params = AggregationRetrieveParams.builder().orgId("orgId").id("id").build()
         assertThat(params).isNotNull
         // path param "orgId"
         assertThat(params.getPathParam(0)).isEqualTo("orgId")

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/AggregationFunctionTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/AggregationFunctionTest.kt
@@ -7,7 +7,7 @@ import java.time.OffsetDateTime
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class AggregationTest {
+class AggregationFunctionTest {
 
     @Test
     fun createAggregation() {
@@ -15,7 +15,7 @@ class AggregationTest {
             Aggregation.builder()
                 .id("id")
                 .version(0L)
-                .aggregation(Aggregation.Aggregation.SUM)
+                .aggregation(Aggregation.AggregationFunction.SUM)
                 .code("code")
                 .createdBy("createdBy")
                 .customFields(
@@ -43,7 +43,7 @@ class AggregationTest {
         assertThat(aggregation).isNotNull
         assertThat(aggregation.id()).isEqualTo("id")
         assertThat(aggregation.version()).isEqualTo(0L)
-        assertThat(aggregation.aggregation()).contains(Aggregation.Aggregation.SUM)
+        assertThat(aggregation.aggregation()).contains(Aggregation.AggregationFunction.SUM)
         assertThat(aggregation.code()).contains("code")
         assertThat(aggregation.createdBy()).contains("createdBy")
         assertThat(aggregation.customFields())

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/AggregationFunctionUpdateParamsTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/AggregationFunctionUpdateParamsTest.kt
@@ -6,7 +6,7 @@ import com.m3ter.sdk.core.JsonValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class AggregationUpdateParamsTest {
+class AggregationFunctionUpdateParamsTest {
 
     @Test
     fun createAggregationUpdateParams() {

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/CompoundAggregationFunctionCreateParamsTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/CompoundAggregationFunctionCreateParamsTest.kt
@@ -6,7 +6,7 @@ import com.m3ter.sdk.core.JsonValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class CompoundAggregationCreateParamsTest {
+class CompoundAggregationFunctionCreateParamsTest {
 
     @Test
     fun createCompoundAggregationCreateParams() {

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/CompoundAggregationFunctionListParamsTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/CompoundAggregationFunctionListParamsTest.kt
@@ -7,11 +7,11 @@ import com.m3ter.sdk.core.http.QueryParams
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class AggregationListParamsTest {
+class CompoundAggregationFunctionListParamsTest {
 
     @Test
-    fun createAggregationListParams() {
-        AggregationListParams.builder()
+    fun createCompoundAggregationListParams() {
+        CompoundAggregationListParams.builder()
             .orgId("orgId")
             .addCode("string")
             .addId("string")
@@ -24,7 +24,7 @@ class AggregationListParamsTest {
     @Test
     fun getQueryParams() {
         val params =
-            AggregationListParams.builder()
+            CompoundAggregationListParams.builder()
                 .orgId("orgId")
                 .addCode("string")
                 .addId("string")
@@ -37,20 +37,20 @@ class AggregationListParamsTest {
         expected.put("ids", "string")
         expected.put("nextToken", "nextToken")
         expected.put("pageSize", "1")
-        expected.put("productId", JsonValue.from(mapOf<String, Any>()))
+        expected.put("productId", JsonValue.from(mapOf<String, Any>()).toString())
         assertThat(params.getQueryParams()).isEqualTo(expected.build())
     }
 
     @Test
     fun getQueryParamsWithoutOptionalFields() {
-        val params = AggregationListParams.builder().orgId("orgId").build()
+        val params = CompoundAggregationListParams.builder().orgId("orgId").build()
         val expected = QueryParams.builder()
         assertThat(params.getQueryParams()).isEqualTo(expected.build())
     }
 
     @Test
     fun getPathParam() {
-        val params = AggregationListParams.builder().orgId("orgId").build()
+        val params = CompoundAggregationListParams.builder().orgId("orgId").build()
         assertThat(params).isNotNull
         // path param "orgId"
         assertThat(params.getPathParam(0)).isEqualTo("orgId")

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/CompoundAggregationFunctionRetrieveParamsTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/CompoundAggregationFunctionRetrieveParamsTest.kt
@@ -5,16 +5,16 @@ package com.m3ter.sdk.models
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class AggregationRetrieveParamsTest {
+class CompoundAggregationFunctionRetrieveParamsTest {
 
     @Test
-    fun createAggregationRetrieveParams() {
-        AggregationRetrieveParams.builder().orgId("orgId").id("id").build()
+    fun createCompoundAggregationRetrieveParams() {
+        CompoundAggregationRetrieveParams.builder().orgId("orgId").id("id").build()
     }
 
     @Test
     fun getPathParam() {
-        val params = AggregationRetrieveParams.builder().orgId("orgId").id("id").build()
+        val params = CompoundAggregationRetrieveParams.builder().orgId("orgId").id("id").build()
         assertThat(params).isNotNull
         // path param "orgId"
         assertThat(params.getPathParam(0)).isEqualTo("orgId")

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/CompoundAggregationFunctionTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/CompoundAggregationFunctionTest.kt
@@ -7,7 +7,7 @@ import java.time.OffsetDateTime
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class CompoundAggregationTest {
+class CompoundAggregationFunctionTest {
 
     @Test
     fun createCompoundAggregation() {

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/CompoundAggregationFunctionUpdateParamsTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/CompoundAggregationFunctionUpdateParamsTest.kt
@@ -6,7 +6,7 @@ import com.m3ter.sdk.core.JsonValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class CompoundAggregationUpdateParamsTest {
+class CompoundAggregationFunctionUpdateParamsTest {
 
     @Test
     fun createCompoundAggregationUpdateParams() {

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/MeterListParamsTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/models/MeterListParamsTest.kt
@@ -37,7 +37,7 @@ class MeterListParamsTest {
         expected.put("ids", "string")
         expected.put("nextToken", "nextToken")
         expected.put("pageSize", "1")
-        expected.put("productId", JsonValue.from(mapOf<String, Any>()))
+        expected.put("productId", JsonValue.from(mapOf<String, Any>()).toString())
         assertThat(params.getQueryParams()).isEqualTo(expected.build())
     }
 

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/services/ErrorHandlingTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/services/ErrorHandlingTest.kt
@@ -72,20 +72,27 @@ class ErrorHandlingTest {
             ProductListPage.of(
                 service,
                 params,
-                Product.builder()
-                    .id("id")
-                    .version(0L)
-                    .code("code")
-                    .createdBy("createdBy")
-                    .customFields(
-                        Product.CustomFields.builder()
-                            .putAdditionalProperty("foo", JsonValue.from("bar"))
-                            .build()
+                ProductListPage.Response.builder()
+                    .data(
+                        listOf(
+                            Product.builder()
+                                .id("id")
+                                .version(0L)
+                                .code("code")
+                                .createdBy("createdBy")
+                                .customFields(
+                                    Product.CustomFields.builder()
+                                        .putAdditionalProperty("foo", JsonValue.from("bar"))
+                                        .build()
+                                )
+                                .dtCreated(OffsetDateTime.parse("2019-12-27T18:11:19.117Z"))
+                                .dtLastModified(OffsetDateTime.parse("2019-12-27T18:11:19.117Z"))
+                                .lastModifiedBy("lastModifiedBy")
+                                .name("name")
+                                .build()
+                        )
                     )
-                    .dtCreated(OffsetDateTime.parse("2019-12-27T18:11:19.117Z"))
-                    .dtLastModified(OffsetDateTime.parse("2019-12-27T18:11:19.117Z"))
-                    .lastModifiedBy("lastModifiedBy")
-                    .name("name")
+                    .nextToken("nextToken")
                     .build()
             )
 

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/services/ServiceParamsTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/services/ServiceParamsTest.kt
@@ -63,22 +63,24 @@ class ServiceParamsTest {
 
         val apiResponse =
             ProductListPage.Response.builder()
-                .addData(
-                    Product.builder()
-                        .id("id")
-                        .version(0L)
-                        .code("code")
-                        .createdBy("createdBy")
-                        .customFields(
-                            Product.CustomFields.builder()
-                                .putAdditionalProperty("foo", JsonValue.from("bar"))
-                                .build()
-                        )
-                        .dtCreated(OffsetDateTime.parse("2019-12-27T18:11:19.117Z"))
-                        .dtLastModified(OffsetDateTime.parse("2019-12-27T18:11:19.117Z"))
-                        .lastModifiedBy("lastModifiedBy")
-                        .name("name")
-                        .build()
+                .data(
+                    listOf(
+                        Product.builder()
+                            .id("id")
+                            .version(0L)
+                            .code("code")
+                            .createdBy("createdBy")
+                            .customFields(
+                                Product.CustomFields.builder()
+                                    .putAdditionalProperty("foo", JsonValue.from("bar"))
+                                    .build()
+                            )
+                            .dtCreated(OffsetDateTime.parse("2019-12-27T18:11:19.117Z"))
+                            .dtLastModified(OffsetDateTime.parse("2019-12-27T18:11:19.117Z"))
+                            .lastModifiedBy("lastModifiedBy")
+                            .name("name")
+                            .build()
+                    )
                 )
                 .nextToken("nextToken")
                 .build()

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/services/blocking/AggregationFunctionServiceTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/services/blocking/AggregationFunctionServiceTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(TestServerExtension::class)
-class AggregationServiceTest {
+class AggregationFunctionServiceTest {
 
     @Test
     fun callCreate() {
@@ -32,11 +32,11 @@ class AggregationServiceTest {
                     .aggregation(AggregationCreateParams.Aggregation.SUM)
                     .meterId("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
                     .name("x")
-                    .quantityPerUnit(0.0)
+                    .quantityPerUnit(1.0)
                     .rounding(AggregationCreateParams.Rounding.UP)
                     .targetField("x")
                     .unit("x")
-                    .code("{1{}}_")
+                    .code("x")
                     .customFields(
                         AggregationCreateParams.CustomFields.builder()
                             .putAdditionalProperty("foo", JsonValue.from("bar"))
@@ -92,11 +92,11 @@ class AggregationServiceTest {
                     .aggregation(AggregationUpdateParams.Aggregation.SUM)
                     .meterId("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
                     .name("x")
-                    .quantityPerUnit(0.0)
+                    .quantityPerUnit(1.0)
                     .rounding(AggregationUpdateParams.Rounding.UP)
                     .targetField("x")
                     .unit("x")
-                    .code("{1{}}_")
+                    .code("x")
                     .customFields(
                         AggregationUpdateParams.CustomFields.builder()
                             .putAdditionalProperty("foo", JsonValue.from("bar"))

--- a/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/services/blocking/CompoundAggregationFunctionServiceTest.kt
+++ b/m3ter-java-core/src/test/kotlin/com/m3ter/sdk/services/blocking/CompoundAggregationFunctionServiceTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(TestServerExtension::class)
-class CompoundAggregationServiceTest {
+class CompoundAggregationFunctionServiceTest {
 
     @Test
     fun callCreate() {
@@ -31,10 +31,10 @@ class CompoundAggregationServiceTest {
                     .orgId("orgId")
                     .calculation("x")
                     .name("x")
-                    .quantityPerUnit(0.0)
+                    .quantityPerUnit(1.0)
                     .rounding(CompoundAggregationCreateParams.Rounding.UP)
                     .unit("x")
-                    .code("{1{}}_")
+                    .code("x")
                     .customFields(
                         CompoundAggregationCreateParams.CustomFields.builder()
                             .putAdditionalProperty("foo", JsonValue.from("bar"))
@@ -84,10 +84,10 @@ class CompoundAggregationServiceTest {
                     .id("id")
                     .calculation("x")
                     .name("x")
-                    .quantityPerUnit(0.0)
+                    .quantityPerUnit(1.0)
                     .rounding(CompoundAggregationUpdateParams.Rounding.UP)
                     .unit("x")
-                    .code("{1{}}_")
+                    .code("x")
                     .customFields(
                         CompoundAggregationUpdateParams.CustomFields.builder()
                             .putAdditionalProperty("foo", JsonValue.from("bar"))


### PR DESCRIPTION
For some reason this is the only language its generated the Aggregation function stuff as an enum, rather than a set of strings... and decided to use the same name for both it and the aggregation class...